### PR TITLE
fix panic

### DIFF
--- a/address.go
+++ b/address.go
@@ -78,7 +78,7 @@ func ReadAddress(ctx context.Context, addressId, uid, sid, sessionKey string) (*
 
 	var resp struct {
 		Data  *Address `json:"data"`
-		Error *Error   `json:"error"`
+		Error Error   `json:"error"`
 	}
 	err = json.Unmarshal(body, &resp)
 	if err != nil {


### PR DESCRIPTION
## 修复 Bug

如果：

```
Error *Error   `json:"error"`
```

而服务器没有返回 error 字段，会在执行：

```
if resp.Error.Code > 0 {
```

时报错：

```
panic: runtime error: invalid memory address or nil pointer dereference
```

## 如何重现？

使用正确的 addressID 传参给 `bot.ReadAddress` , 100% 重现。